### PR TITLE
Set epigraph font to \normalsize

### DIFF
--- a/msu-thesis.cls
+++ b/msu-thesis.cls
@@ -546,6 +546,10 @@
 \@ifpackageloaded{apacite}{\@tocbibfalse}{} % added 6/22/17
 %\topskip=0pt % setting this because the Grad School doesn’t know how to measure -changed back 6/15/17
 \checkandfixthelayout
+
+% Set epigraph fonts to \normalsize
+\renewcommand{\epigraphsize}{\normalsize}
+
 %
 % set up subscript sizes so that 10 pt is the smallest
 % (MSU Requirement)


### PR DESCRIPTION
The grad etd seems to require ALL text fonts to be exactly the same size. By default, the epigraph package (loaded by the memoir class) uses 1 size smaller than the text size. This changes it to \normalsize.